### PR TITLE
fix: import performance explicitly

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,3 +1,4 @@
+import { performance } from 'perf_hooks'
 import {
   defineNuxtModule,
   createResolver,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently this module doesn't run on Node 14. The following error is thrown:

```
 ERROR  Could not build tokens!                                               design-tokens 15:40:33
 ERROR  performance is not defined                                            design-tokens 15:40:33
```

This PR resolves the issue by explicitly importing performance.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
