### PR TITLE
fix: rename types.d.ts to types.ts

### DIFF
--- a/docs/content/1.guide/3.API.md
+++ b/docs/content/1.guide/3.API.md
@@ -66,7 +66,7 @@ Theme tokens gets processed by [Style Dictionary](https://amzn.github.io/style-d
   - `tokens.json` if you want to import it from a JSON context.
   - `index.ts` to import it from runtime or from any TypeScript context.
   - `index.js` to import it from runtime or from any JavaScript context.
-  - `types.d.ts` for global type inference (`$dt()`, `$tokens()`, `useTokens()`, `defineTokens`, `nuxt.config.style.tokens`).
+  - `types.ts` for global type inference (`$dt()`, `$tokens()`, `useTokens()`, `defineTokens`, `nuxt.config.style.tokens`).
 
 - **Composable usage**
   ```ts

--- a/src/config/generate.ts
+++ b/src/config/generate.ts
@@ -3,7 +3,7 @@ import { rm, writeFile } from 'fs/promises'
 import type { Core as Instance } from 'browser-style-dictionary/types/browser'
 import StyleDictionary from 'browser-style-dictionary/browser.js'
 import { Dictionary } from 'browser-style-dictionary/types/Dictionary'
-import { tsTypesDeclaration, tsFull, jsFull, walkTokens } from '../formats'
+import { tsTypesExports, tsFull, jsFull, walkTokens } from '../formats'
 import type { NuxtStyleTheme } from '../index'
 import { createTokensDir } from './load'
 
@@ -15,7 +15,7 @@ export const stubTokens = async (buildPath: string, force = false) => {
     'tokens.json': () => '{}',
     'index.js': jsFull,
     'index.ts': tsFull,
-    'types.ts': tsTypesDeclaration
+    'types.ts': tsTypesExports
   }
 
   for (const [file, stubbingFunction] of Object.entries(files)) {
@@ -40,7 +40,7 @@ export const getStyleDictionaryInstance = async (tokens: NuxtStyleTheme, buildPa
   styleDictionary.registerFormat({
     name: 'typescript/types-declaration',
     formatter ({ dictionary }) {
-      return tsTypesDeclaration(dictionary)
+      return tsTypesExports(dictionary)
     }
   })
 

--- a/src/config/generate.ts
+++ b/src/config/generate.ts
@@ -15,7 +15,7 @@ export const stubTokens = async (buildPath: string, force = false) => {
     'tokens.json': () => '{}',
     'index.js': jsFull,
     'index.ts': tsFull,
-    'types.d.ts': tsTypesDeclaration
+    'types.ts': tsTypesDeclaration
   }
 
   for (const [file, stubbingFunction] of Object.entries(files)) {
@@ -104,7 +104,7 @@ export const getStyleDictionaryInstance = async (tokens: NuxtStyleTheme, buildPa
             format: 'typescript/full'
           },
           {
-            destination: 'types.d.ts',
+            destination: 'types.ts',
             format: 'typescript/types-declaration'
           }
         ]
@@ -146,8 +146,8 @@ const generateTokensOutputs = (styleDictionary: Instance, silent = true) => new 
     try {
       // Weird trick to disable nasty logging
       if (silent) {
-      // @ts-ignore
-      // eslint-disable-next-line no-console
+        // @ts-ignore
+        // eslint-disable-next-line no-console
         console._log = console.log
         // eslint-disable-next-line no-console
         console.log = () => {}
@@ -170,8 +170,8 @@ const generateTokensOutputs = (styleDictionary: Instance, silent = true) => new 
 
       // Weird trick to disable nasty logging
       if (silent) {
-      // @ts-ignore
-      // eslint-disable-next-line no-console
+        // @ts-ignore
+        // eslint-disable-next-line no-console
         console.log = console._log
       }
     } catch (e) {

--- a/src/formats/index.ts
+++ b/src/formats/index.ts
@@ -41,9 +41,9 @@ export const tsTypesDeclaration = ({ tokens }: Dictionary) => {
 export const tsFull = ({ tokens }: Dictionary) => {
   const { type, aliased } = walkTokens(tokens, false)
 
-  let result = 'import type { NuxtThemeTokens,   NuxtThemeTokensPaths, TokenHelperOptions } from \'./types.d\'\n\n'
+  let result = 'import type { NuxtThemeTokens,   NuxtThemeTokensPaths, TokenHelperOptions } from \'./types\'\n\n'
 
-  result = result + 'export * from \'./types.d\'\n\n'
+  result = result + 'export * from \'./types\'\n\n'
 
   result = result + `${getFunction}\n\n`
 

--- a/src/formats/index.ts
+++ b/src/formats/index.ts
@@ -10,7 +10,7 @@ export { walkTokens }
  * Formats
  */
 
-export const tsTypesDeclaration = ({ tokens }: Dictionary) => {
+export const tsTypesExports = ({ tokens }: Dictionary) => {
   const { type } = walkTokens(tokens)
 
   let result = 'import type { Ref } from \'vue\'\n\n'

--- a/src/module.ts
+++ b/src/module.ts
@@ -134,7 +134,7 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.alias = nuxt.options.alias || {}
     nuxt.options.alias['#design-tokens'] = resolveTokensDir('index')
     nuxt.options.alias['#design-tokens/style'] = resolveTokensDir('tokens.css')
-    nuxt.options.alias['#design-tokens/types'] = resolveTokensDir('types.d')
+    nuxt.options.alias['#design-tokens/types'] = resolveTokensDir('types')
 
     // Inject CSS
     // nuxt.options.css = nuxt.options.css || []
@@ -169,7 +169,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Inject typings
     nuxt.hook('prepare:types', (opts) => {
-      opts.references.push({ path: resolveTokensDir('types.d.ts') })
+      opts.references.push({ path: resolveTokensDir('types.ts') })
     })
 
     // Initial build


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

These are just a few quick refactors to rename the `types.d.ts` to `types.ts` file. (It doesn't seem to be written as a declaration file, and it's being imported from directly as well.) Drop me a DM if it would be helpful; I'm sure there are areas I've not properly tested but everything still seems to be working.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
